### PR TITLE
Traversing fieldset elements fix

### DIFF
--- a/islandora_plupload.module
+++ b/islandora_plupload.module
@@ -50,15 +50,10 @@ function islandora_plupload_form_alter(&$form, &$form_state, $form_id) {
 function islandora_plupload_alter_managed_files(&$form) {
   $islandora_plupload_max = variable_get('islandora_plupload_max_filesize', 3000);
   if (is_array($form) && !empty($form)) {
+    // There must be a better way to get elements of type 'managed_file'
     foreach ($form as &$element) {
-      // There must be a better way to get the children.
       if (isset($element['#type']) && $element['#type'] === 'fieldset') {
-        $children = element_children($element);
-        if (is_array($children) && (count($children) > 0)) {
-          foreach ($children as $key) {
-            islandora_plupload_alter_managed_files($form[$key]);
-          }
-        }
+        islandora_plupload_alter_managed_files($element);
       }
       if (isset($element['#type']) && $element['#type'] === 'managed_file') {
         $element['#type'] = 'plupload';


### PR DESCRIPTION
I was trying to get plupload to display on the "Add datastream" form but it would not show up - when I looked through the add datastream form, I saw the form had a fieldset with the managed_file form element inside. Once I looked at the islandora_plupload module, I saw the manner in which it processed fieldset elements seemed incorrect. The pull request simplifies the code so it doesn't try to see if the fieldset has children; it just goes through it as if it is a subform (which is how the initial 'islandora_plupload_alter_managed_files' expects it.
