### PR TITLE
Force insert image/jp2 mimetype into supported plupload mimeTypes var…

### DIFF
--- a/js/element.js
+++ b/js/element.js
@@ -36,4 +36,11 @@
       });
     }
   };
+  // XXX: To allow for jp2 files to be uploaded when a plupload field is using
+  // extension restriction with jp2 as one of the restricted options. The
+  // MIME type must be added to plupload support MIME types for it to be added
+  // in the <input> accept Attribute. Since the plupload version is below 2.x
+  // the plupload mimeTypes variable needs to be modified directly using the
+  // plupload object, instead of using mOxie.Mime.addMimeType("image/jp2, jp2").
+  window.plupload.mimeTypes['jp2'] = 'image/jp2';
 })(jQuery);


### PR DESCRIPTION
…iable to allow for jp2 extension restriction when using plupload field.
