### PR TITLE
Make spinners spin again.

### DIFF
--- a/js/element.js
+++ b/js/element.js
@@ -1,5 +1,5 @@
 /*jshint browser: true, devel:true*/
-/*global jQuery, Drupal, plupload*/
+/*global jQuery, Drupal, Spinner*/
 /**
  * @file
  * Enforce max_file_count for Plupload elements.
@@ -31,6 +31,26 @@
                 $('.plupload_add', element).show('slow');
               }
             });
+
+            // If there is a spinner on the form then make it spin!
+            if (Drupal.behaviors.spinner !== undefined) {
+              if (settings.plupload[id].submit_element !== undefined) {
+                $(settings.plupload[id].submit_element).click(function(event) {
+                  if (event.originalEvent === undefined) {
+                    var form = $(this).parents('form');
+                    if (settings.spinner['edit-next'] !== undefined && form.data('submitted') === undefined) {
+                      form.data('submitted', true);
+                      var spin = settings.spinner['edit-next'];
+                      var spinner = new Spinner(spin.opts);
+                      spinner.spin(form.get(0));
+                      $('#edit-next').after(spin.message);
+                      $('#edit-next').hide();
+                      $('#edit-prev').hide();
+                    }
+                  }
+                });
+              }
+            }
           }
         });
       });


### PR DESCRIPTION
## Summary
The islandora_plupload javascript stops the spinner from spinning when ingesting objects in the islandora ingest form, leaving the opportunity to click the ingest button twice and get some nasty error messages. 

This updates the JS so that it checks if there should be a spinner, and then if there should be a spinner it makes it spin! Spin baby spin. 😎 

## Test case
- Enable plupload on a form
- Go to the final ingest screen
- Add a file to plupload
- *Don't* click the 'upload files' button in plupload
- Click ingest

Without the patch the files should upload with the nice progress bar, then it will submit the form, but there will be no spinner. Without the spinner if you click ingest again at this point you will get a :metal: gnarly error message.

Use patch and you should see a spinner after the files have been uploaded. 🕶 