### PR TITLE
Widen selector used

### DIFF
--- a/islandora_plupload.module
+++ b/islandora_plupload.module
@@ -73,7 +73,7 @@ function islandora_plupload_alter_managed_files(&$form) {
           'max_file_count' => 1,
         );
         $element['#plupload_settings'] = $settings;
-        $element['#submit_element'] = '#edit-next';
+        $element['#submit_element'] = '#edit-next,#edit-submit';
         $element['#element_validate'][] = 'islandora_plupload_element_validate';
         drupal_add_js(drupal_get_path('module', 'islandora_plupload') . '/js/element.js', array('type' => 'file', 'scope' => 'footer'));
       }


### PR DESCRIPTION
## Changes

Widen the `#submit-element` form property so it covers the importer forms as well. Before this change the auto-submit functionality would not work because we were passing a selector that does not exist. 

## Test Case

- Enable islandora_plupload
- Go to collection and use the zip importer
- Don't upload the file, just hit submit

Before the patch: 
- file will upload
- form will not submit

After the patch: 
- file will upload
- form will submit