### PR TITLE
let's make the file not permanent before saving

### DIFF
--- a/islandora_plupload.module
+++ b/islandora_plupload.module
@@ -112,6 +112,7 @@ function islandora_plupload_element_validate(array $element, array &$form_state)
     $file->filename = $first_element_value['name'];
     $mime_detect = new MimeDetect();
     $file->filemime = $mime_detect->getMimeType($file->filename);
+    $file->status = 0;
     islandora_plupload_file_save($file);
     $element_value = $file->fid;
   }


### PR DESCRIPTION
The drupal plupload module actually adds the files to the database as permanent https://git.drupalcode.org/project/plupload/-/blob/7.x-2.x/plupload.module#L479

So let's undo that so that the cron can collect the temporary files. 